### PR TITLE
Chore/replace pandoc source

### DIFF
--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -15,16 +15,6 @@ function install_go () {
     dnf install -y go
 }
 
-function install_pandoc () {
-    run_log 0 "Starting base dependency install"
-    dnf -y install wget
-    wget -c https://github.com/jgm/pandoc/releases/download/3.1/pandoc-3.1-linux-amd64.tar.gz
-    tar zxvf pandoc-3.1-linux-amd64.tar.gz
-    cp -rp pandoc-3.1/bin/* "$BIN_DIR"/
-    rm -rf pandoc-3.1
-    rm -f pandoc-3.1-linux-amd64.tar.gz
-}
-
 function install_utils () {
     run_log 0 "Starting base dependency install"
     dnf install -y which pv asciinema make jq wget

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,6 @@ function build () {
     install_cosign
     install_gcr
     install_oras
-    install_pandoc
 }
 
 function install_demo_utils () {

--- a/scripts/pandoc.sh
+++ b/scripts/pandoc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PANDOC_IMAGE="docker.io/pandoc/core"
-PANDOC_IMAGE_TAG="latest"
+PANDOC_IMAGE_TAG="3.1"
 CONTAINER_CMD=$(command -pv podman || command -pv docker)
 
 if [ ! $(command -v pandoc >/dev/null) ];

--- a/scripts/pandoc.sh
+++ b/scripts/pandoc.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+PANDOC_IMAGE="docker.io/pandoc/core"
+PANDOC_IMAGE_TAG="latest"
+CONTAINER_CMD=$(command -pv podman || command -pv docker)
+
+if [ ! $(command -v pandoc >/dev/null) ];
+then
+  function pandoc {
+    ARGS=$@
+    CMD="$CONTAINER_CMD run -it --rm -w /demo/trestle-workspace -v $(pwd):/demo/trestle-workspace $PANDOC_IMAGE:$PANDOC_IMAGE_TAG $@"
+    bash -c "$CMD"
+  }
+fi

--- a/scripts/trestle.sh
+++ b/scripts/trestle.sh
@@ -19,12 +19,6 @@ then
     bash -c "$CMD"
   }
 
-  function pandoc {
-    ARGS=$@
-    CMD="$CONTAINER_CMD run -it --rm -w /demo/trestle-workspace -v $(pwd):/demo/trestle-workspace $TRESTLE_IMAGE:$TRESTLE_IMAGE_TAG $PANDOC_CMD_IMAGE $@"
-    bash -c "$CMD"
-  }
-
   function python {
     ARGS=$@
     CMD="$CONTAINER_CMD run -it --rm -w /demo/trestle-workspace -v $(pwd):/demo/trestle-workspace $TRESTLE_IMAGE:$TRESTLE_IMAGE_TAG $PYTHON_CMD_IMAGE $@"


### PR DESCRIPTION
Change: Instead of installing pandoc from a pre-compiled release, use the official Docker image when pandoc is not installed on the local system.