### PR TITLE
feat: adds the ability to skip during regeneration

### DIFF
--- a/mk/regenerate.mk
+++ b/mk/regenerate.mk
@@ -4,17 +4,21 @@
 
 scripts_dir :=$(shell realpath $(dir $(lastword $(MAKEFILE_LIST)))../scripts)
 
+SKIP_COMPONENTS ?= "hello world"
+SKIP_PROFILES ?= ""
+SKIP_CATALOGS ?= ""
+
 regenerate: regenerate-catalogs regenerate-profiles regenerate-cd
 .PHONY: regenerate
 
 regenerate-catalogs:
-	@source $(scripts_dir)/regenerate.sh && regenerate_catalogs
+	@source $(scripts_dir)/regenerate.sh && regenerate_catalogs ${SKIP_CATALOGS}
 .PHONY: regenerate-catalogs
 
 regenerate-profiles:
-	@source $(scripts_dir)/regenerate.sh && regenerate_profiles
+	@source $(scripts_dir)/regenerate.sh && regenerate_profiles ${SKIP_PROFILES}
 .PHONY: regenerate-profiles
 
 regenerate-cd:
-	@source $(scripts_dir)/regenerate.sh && regenerate_components
+	@source $(scripts_dir)/regenerate.sh && regenerate_components ${SKIP_COMPONENTS}
 .PHONY: regenerate-cd

--- a/mk/regenerate.mk.example.txt
+++ b/mk/regenerate.mk.example.txt
@@ -1,0 +1,8 @@
+# Include the library makefile
+include ./regenerate.mk
+# All the available targets can be listed using `make help`
+
+
+SKIP_COMPONENTS := "comp_a" "comp_b"
+SKIP_CATALOG := "my_catalog"
+SKIP_PROFILES := "my_profile"

--- a/scripts/regenerate.sh
+++ b/scripts/regenerate.sh
@@ -5,12 +5,32 @@ SCRIPT_DIR="$(realpath "$(dirname "$BASH_SOURCE")")"
 source "$SCRIPT_DIR/logging.sh"
 source "$SCRIPT_DIR/trestle.sh"
 
+function containsElement() {
+    local value="$1"
+    shift
+    local array=("$@")
+    local element
+
+    for element in "${array[@]}"; do
+        if [[ "$element" == "$value" ]]; then
+            return 0 # Value found, return success
+        fi
+    done
+
+    return 1 # Value not found, return failure
+}
+
 function regenerate_catalogs() {
+local skip=("$@")
 catalogs=$(find ./catalogs -mindepth 1 -type d | wc -l)
 if [ "$catalogs" -gt 0 ]; then
   for d in ./catalogs/* ; do
     catalog=$(basename "$d")
-    run_log 0 "Regenerating ${catalog}"
+     if containsElement "$catalog" "${skip[@]}"; then
+        run_log 0 "Skipping $catalog"
+        continue
+    fi
+    run_log 0 "Regenerating $catalog"
     trestle author catalog-generate --name "$catalog" --output markdown/catalogs/"$catalog"
   done
 else
@@ -19,13 +39,17 @@ fi
 }
 
 function regenerate_profiles() {
+local skip=("$@")
 profiles=$(find ./profiles -mindepth 1 -type d | wc -l)
 if [ "$profiles" -gt 0 ]; then
   for d in ./profiles/* ; do
       profile=$(basename "$d")
-      echo "PROFILE BASENAME: $profile"
-         run_log 0 "Regenerating ${profile}"
-         trestle author profile-generate --output markdown/profiles/"$profile" --name "$profile"
+      if containsElement "$profile" "${skip[@]}"; then
+        run_log 0 "Skipping $profile"
+        continue
+      fi
+      run_log 0 "Regenerating $profile"
+      trestle author profile-generate --output markdown/profiles/"$profile" --name "$profile"
   done
   else
       run_log 0 "No profiles found"
@@ -33,14 +57,17 @@ if [ "$profiles" -gt 0 ]; then
 }
 
 function regenerate_components() {
+local skip=("$@")
 components=$(find ./component-definitions -mindepth 1 -type d | wc -l)
 if [ "$components" -gt 0 ]; then
   for d in ./component-definitions/* ; do
     component=$(basename "$d")
-    if [ "$component" != "hello-world" ]; then
-      run_log 0 "Regenerating ${component}"
-      trestle author component-generate --output markdown/components/"$component" --name "$component"
+    if containsElement "$component" "${skip[@]}"; then
+        run_log 0 "Skipping $component"
+        continue
     fi
+    run_log 0 "Regenerating $component"
+    trestle author component-generate --output markdown/components/"$component" --name "$component"
   done
 else
     run_log 0 "No components found"


### PR DESCRIPTION
## Changes

The PR adds the ability to skip by name when doing regeneration of OSCAL catalogs, profile, and component definitions. It also adds an example file on how to use the variables.

This is useful in a of couple cases:

- You want to be able to run `make regenerate` to regenerate with multiple models, but you need to skip one or more.
- You are importing a profile into another profile and you only want to edit the downstream profile in the repository.

## How was this tested?

Tested using the branch from this [PR](https://github.com/RedHatProductSecurity/oscal-profiles/pull/1).

1. Clone both repositories
```
git clone --branch feat/allow-skip-regenerate https://github.com/jpower432/oscal-automation-libs.git
git clone --branch feat/initial-setup https://github.com/jpower432/oscal-profiles.git
```
2. Copy the content from `oscal-automation-libs` to `vendor` in `oscal-profiles`  
`cp -r oscal-automation-libs/* oscal-profiles/vendor`
3. Run `cd oscal-profiles`
3. Add `SKIP_PROFILES := "fedramp_rev5_high"` to the Makefile in `oscal-profiles`
4. Run `make regenerate-profiles`

**Notes**
If you have git `subtree`, just remove the `vendor` directory and add back with `git subtree add --prefix vendor/ https://github.com/jpower432/oscal-automation-libs.git feat/allow-skip-regenerate --squash`. This means you don't have to clone this repo in the first step.

Acceptance - `fedramp_rev5_high` is skipped
