### PR TITLE
feat: adds ability to set commit author from top-level scripts

### DIFF
--- a/scripts/auto-commit-push.sh
+++ b/scripts/auto-commit-push.sh
@@ -12,9 +12,9 @@ function clone_repo() {
 # Function to commit changes locally in git
 function local_commit () {
     local COMMIT_MESSAGE="${1:-"chore: automatic content update"}"
-    local COMMIT_USER="${2:-"github-actions[bot]"}"
-    local COMMIT_EMAIL="${3:-"github-actions@github.com"}"
-    local COMMIT_AUTHOR="${4:-"github-actions[bot] <github-actions@github.com>"}"
+    local COMMIT_AUTHOR="${2:-"github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"}"
+    local COMMIT_USER="${3:-"github-actions[bot]"}"
+    local COMMIT_EMAIL="${4:-"41898282+github-actions[bot]@users.noreply.github.com"}"
 
     git -c user.name="$COMMIT_USER" -c user.email="$COMMIT_EMAIL" \
         commit -m "$COMMIT_MESSAGE" --author "$COMMIT_AUTHOR"
@@ -39,9 +39,9 @@ function push_to_remote() {
 
 # Function to create a new branch and GitHub pull request
 function create_branch_pull_request() {
-    local PR_TITLE="${1:-"chore: sync OSCAL content"}"
-    local PR_BODY="${2:-"chore: automatic content update"}"
-    local BRANCH="${3:?"branch is required"}"
+    local BRANCH="${1:?"branch is required"}"
+    local PR_TITLE="${2:-"chore: sync OSCAL content"}"
+    local PR_BODY="${3:-"chore: automatic content update"}"
     push_to_remote "$BRANCH"
     gh pr create -t "$PR_TITLE" -b "$PR_BODY" -B "main" -H "$BRANCH" --draft
 }

--- a/scripts/update-from-upstream.sh
+++ b/scripts/update-from-upstream.sh
@@ -25,13 +25,15 @@ function main() {
     DEFAULT_INCLUDE_DIRS=()
     BRANCH=""
     REPO_URL=""
+    AUTHOR=""
     patterns=()
 
     # Parse command line options
-    while getopts ":b:r:p:i:" opt; do
+    while getopts ":b:r:a:p:i:" opt; do
         case $opt in
             b) BRANCH="$OPTARG";;
             r) REPO_URL="$OPTARG";;
+            a) AUTHOR="$OPTARG";;
             p) patterns+=("$OPTARG");;
             i) include_dirs+=("$OPTARG");;
             \?) echo "Invalid option -$OPTARG" >&2; exit 1;;
@@ -40,7 +42,7 @@ function main() {
 
     # Check if required arguments are provided
     if [ -z "$BRANCH" ] || [ -z "$REPO_URL" ] || [ ${#patterns[@]} -eq 0 ]; then
-    echo "Usage: update-from-upstream.sh -b branch -r repo_url -p pattern1 -p pattern2 ... [-i include_dir1] [-i include_dir2] ..."
+    echo "Usage: update-from-upstream.sh -b branch -r repo_url -a author -p pattern1 -p pattern2 ... [-i include_dir1] [-i include_dir2] ..."
     exit 1
     fi
 
@@ -83,8 +85,8 @@ function main() {
         add_files "${patterns[@]}"
 
         if [ -n "$(git status --untracked-files=no --porcelain)" ]; then
-            local_commit "$COMMIT_BODY"
-            create_branch_pull_request "$COMMIT_TITLE" "$COMMIT_BODY" "autoupdate_$GITHUB_RUN_ID"
+            local_commit "$COMMIT_BODY" "$AUTHOR"
+            create_branch_pull_request "autoupdate_$GITHUB_RUN_ID" "$COMMIT_TITLE" "$COMMIT_BODY"
         else
             run_log 0 "Nothing to commit."
         fi

--- a/scripts/update-push.sh
+++ b/scripts/update-push.sh
@@ -18,18 +18,20 @@ source "$SCRIPT_DIR/logging.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/auto-commit-push.sh"
 
-USAGE="Usage: update-push.sh [-b branch] [-c commit_msg] <patterns>"
+USAGE="Usage: update-push.sh [-b branch] [-c commit_msg] [-a author] <patterns>"
 
 function main() {
 
     DEFAULT_COMMIT_MSG="chore: automatic content update"
     BRANCH=""
+    AUTHOR=""
 
     # Parse command line options
-    while getopts ":b:c:" opt; do
+    while getopts ":b:c:a:" opt; do
         case $opt in
             b) BRANCH="$OPTARG";;
             c) commit_msg="$OPTARG";;
+            a) AUTHOR="$OPTARG";;
             \?) echo "Invalid option -$OPTARG" >&2; exit 1;;
         esac
     done
@@ -53,7 +55,7 @@ function main() {
         add_files "${patterns[@]}"
 
         if [ -n "$(git status --untracked-files=no --porcelain)" ]; then
-            local_commit "$COMMIT_BODY"
+            local_commit "$COMMIT_BODY" "$AUTHOR"
             push_to_remote "$BRANCH"
         else
             run_log 0 "Nothing to commit."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -18,16 +18,18 @@ source "$SCRIPT_DIR/logging.sh"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/auto-commit-push.sh"
 
-USAGE="Usage: update.sh [-c commit_msg] <patterns>"
+USAGE="Usage: update.sh [-c commit_msg] [-a author] <patterns>"
 
 function main() {
 
     DEFAULT_COMMIT_MSG="chore: automatic content update"
+    AUTHOR=""
 
     # Parse command line options
-    while getopts ":c:" opt; do
+    while getopts ":c:a:" opt; do
       case $opt in
         c) commit_msg="$OPTARG";;
+        a) AUTHOR="$OPTARG";;
         \?) echo "Invalid option -$OPTARG" >&2; exit 1;;
       esac
     done
@@ -57,8 +59,8 @@ function main() {
       if [ -z "$(git status --untracked-files=no --porcelain)" ]; then
           run_log 0 "Nothing to commit"
       else
-          local_commit "$COMMIT_BODY"
-          create_branch_pull_request "$COMMIT_TITLE" "$COMMIT_BODY" "autoupdate_$GITHUB_RUN_ID" 
+          local_commit "$COMMIT_BODY" "$AUTHOR"
+          create_branch_pull_request "autoupdate_$GITHUB_RUN_ID" "$COMMIT_TITLE" "$COMMIT_BODY"
       fi
     fi
 }


### PR DESCRIPTION
This PR changes:

- Fixes the GitHub Bot email to allow it to be recognized as a valid user
- Allows the commit author to be set from the top-level updates scripts (can be set to the user who triggered the workflow for enhanced traceability) 