### PR TITLE
docs: adding deprecation message

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter@v7
+        uses: oxsecurity/megalinter@5199c6377b4cb7faff749a1971636f3343db9fe6 # pin@v7
         env:
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi AS build
+FROM registry.access.redhat.com/ubi8/ubi:latest AS build
 
 WORKDIR /demo
 
@@ -9,7 +9,7 @@ ENV BIN_DIR=/demo/bin/ PATH=$PATH:BIN_DIR
 
 RUN ./scripts/install.sh build
 
-FROM registry.access.redhat.com/ubi8/python-38 AS demo
+FROM registry.access.redhat.com/ubi8/python-38:latest AS demo
 
 COPY requirements.txt requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# oscal-automation-libs
+# oscal-automation-libs (DEPRECATED)
+
+> #### ** This repository has been deprecated.  Please refer to [trestle-bot](https://github.com/RedHatProductSecurity/trestle-bot) for an updated OSCAL automation tool. **
 
 A common repository to share code for Makefiles, helper scripts, and IaC to support repositories with OSCAL content.
 


### PR DESCRIPTION
Adding deprecation message to README.  Users should now leverage [trestle-bot](https://github.com/RedHatProductSecurity/trestle-bot) for OSCAL automation tooling.

Fixes [Issues #24](https://github.com/RedHatProductSecurity/oscal-automation-libs/issues/24)